### PR TITLE
Few libraries fix to allow compilation on Ubuntu.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package (PCL REQUIRED)
 find_package (Eigen3 REQUIRED)
 find_package (CGAL REQUIRED)
-find_package (Boost REQUIRED COMPONENTS program_options filesystem thread)
+find_package (Boost REQUIRED COMPONENTS program_options filesystem)
 find_package (SuiteSparse REQUIRED)
 
 add_library (PCL::PCL INTERFACE IMPORTED)
@@ -35,8 +35,6 @@ target_link_libraries (pclbo
     PUBLIC
         PCL::PCL
     PRIVATE
-        pthread
-        Boost::thread
         CGAL::CGAL
         Eigen3::Eigen
         SuiteSparse::Cholmod)
@@ -71,7 +69,7 @@ target_link_libraries (heat
 
 
 add_executable (mesh_geoheat EXCLUDE_FROM_ALL src/mesh_geoheat_demo.cpp)
-target_include_directories (mesh_geoheat PUBLIC ${SuiteSparse_INCLUDE_DIRS})
+target_include_directories (mesh_geoheat PRIVATE ${SuiteSparse_INCLUDE_DIRS})
 target_link_libraries (mesh_geoheat
   PRIVATE
     pclbo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,11 @@ target_link_libraries (heat
 
 
 add_executable (mesh_geoheat EXCLUDE_FROM_ALL src/mesh_geoheat_demo.cpp)
-target_link_libraries (mesh_geoheat 
+target_include_directories (mesh_geoheat PUBLIC ${SuiteSparse_INCLUDE_DIRS})
+target_link_libraries (mesh_geoheat
   PRIVATE
     pclbo
     Boost::program_options
-    Boost::filesystem)
+    Boost::filesystem
+    cholmod
+        )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package (PCL REQUIRED)
 find_package (Eigen3 REQUIRED)
 find_package (CGAL REQUIRED)
-find_package (Boost REQUIRED COMPONENTS program_options filesystem)
+find_package (Boost REQUIRED COMPONENTS program_options filesystem thread)
 find_package (SuiteSparse REQUIRED)
 
 add_library (PCL::PCL INTERFACE IMPORTED)
@@ -35,6 +35,8 @@ target_link_libraries (pclbo
     PUBLIC
         PCL::PCL
     PRIVATE
+        pthread
+        Boost::thread
         CGAL::CGAL
         Eigen3::Eigen
         SuiteSparse::Cholmod)

--- a/include/pclbo/geodesics/meshgeoheat.h
+++ b/include/pclbo/geodesics/meshgeoheat.h
@@ -8,7 +8,6 @@
 #include <pcl/common/common_headers.h>
 #include <pcl/PolygonMesh.h>
 #include <pcl/conversions.h>
-
 #include <pclbo/meshlbo.h>
 
 namespace pclbo {

--- a/include/pclbo/pclbo.h
+++ b/include/pclbo/pclbo.h
@@ -2,7 +2,6 @@
 #define PC_LBO_DIFFUSION_HH
 
 #include <cmath>
-#include <boost/thread/thread.hpp>
 #include <Eigen/Eigen>
 
 #include <pcl/common/geometry.h>

--- a/include/pclbo/pclbo.h
+++ b/include/pclbo/pclbo.h
@@ -2,6 +2,7 @@
 #define PC_LBO_DIFFUSION_HH
 
 #include <cmath>
+#include <boost/thread/thread.hpp>
 #include <Eigen/Eigen>
 
 #include <pcl/common/geometry.h>

--- a/src/meshgeoheat.cpp
+++ b/src/meshgeoheat.cpp
@@ -87,7 +87,7 @@ pclbo::MeshGeoHeat::getDistancesFrom(const int x) {
     // Find the minimum not nan number
     double minimum = std::numeric_limits<double>::infinity();
     for (const auto& v : dist) {
-        if (!isnan(v) && v < minimum) {
+        if (!std::isnan(v) && v < minimum) {
             minimum = v;
         }
     }


### PR DESCRIPTION
I added the pthread and the Boost::thread library linking instruction and the "std" namespace for the isnan function. It now compile on Ubuntu 20.04. 